### PR TITLE
[PlatformIndicators] Use semantic for DND icon colour

### DIFF
--- a/plugins/PlatformIndicators/src/colors.ts
+++ b/plugins/PlatformIndicators/src/colors.ts
@@ -1,6 +1,6 @@
 import { findByProps, findByStoreName } from "@vendetta/metro";
 import { ReactNative, chroma } from "@vendetta/metro/common";
-import { rawColors } from "@vendetta/ui";
+import { rawColors, semanticColors } from "@vendetta/ui";
 
 /*const { colors, meta } = findByProps("colors", "meta");
 const ThemeStore = findByStoreName("ThemeStore");
@@ -9,7 +9,7 @@ const color = meta.resolveSemanticColor(ThemeStore.theme, colors.STATUS_ONLINE)*
 
 const Colors = {
     online: chroma(rawColors.GREEN_360).hex(),
-    dnd: chroma(rawColors.RED_400).hex(),
+    dnd: chroma(semanticColors.STATUS_DND).hex(),
     idle: chroma(rawColors.YELLOW_300).hex(),
     offline: chroma(rawColors.PRIMARY_400).hex(),  
 };


### PR DESCRIPTION
STATUS_DND still uses RED_400 as it's raw color so themers don't need to change anything in their theme, it just makes it easier to alter the colour bcuz discord uses the same strings in too many places